### PR TITLE
Fix parâmetros pass

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ extern crate llvm_sys as llvm;
 mod ast;
 mod gen;
 mod grammar;
+mod symbol_table;
 
 use clap::{app_from_crate, crate_authors, crate_description, crate_name, crate_version, Arg};
 use std::env;
@@ -24,11 +25,12 @@ fn main() {
             Arg::with_name("input")
                 .takes_value(true)
                 .value_name("FILE")
+                .required(true)
                 .help("File to compile"),
         )
         .get_matches();
 
-    let input_file_name = match matches.value_of("i") {
+    let input_file_name = match matches.value_of("input") {
         Some(f) => f,
         None => exit(ExitCodes::FileError as i32),
     };

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -1,0 +1,53 @@
+use std::collections::{HashMap, LinkedList};
+
+use llvm::core::*;
+use llvm::prelude::*;
+
+#[derive(Clone, Debug)]
+pub enum Symbol {
+    Variable(LLVMValueRef),
+    Array(u32, LLVMValueRef),
+    ArrayRef(LLVMValueRef),
+    Func(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct SymbolTable {
+    list: LinkedList<HashMap<String, Symbol>>,
+}
+
+impl SymbolTable {
+    pub fn new() -> SymbolTable {
+        let mut linked = LinkedList::new();
+        linked.push_front(HashMap::new());
+        SymbolTable { list: linked }
+    }
+
+    /// Get the symbol `identifier` in the current scope or in a lower scope
+    pub fn get(self: &Self, identifier: &String) -> Result<&Symbol, ()> {
+        for hash_symbol in self.list.iter() {
+            if let Some(symbol) = hash_symbol.get(identifier) {
+                return Ok(symbol);
+            }
+        }
+
+        Err(())
+    }
+
+    /// Should be call on a new ssope creation
+    pub fn initialize_scope(self: &mut Self) {
+        self.list.push_front(HashMap::new());
+    }
+
+    /// To be used when the scope ended
+    pub fn kill_scope(self: &mut Self) {
+        self.list.pop_front();
+    }
+
+    /// This function only set a identifier in the scope, possibly it will 
+    /// overwrite the value thats is current in the actual scope
+    pub fn set(self: &mut Self, identifier: &String, symbol: Symbol) {
+        let front = self.list.front_mut().unwrap();
+        front.insert(identifier.to_string(), symbol);
+    }
+}


### PR DESCRIPTION
Acho que achei a solução

Com base nessa [resposta](https://stackoverflow.com/questions/16823487/llvm-ir-function-with-an-array-parameter) do stack eu gerei o llvm do seguinte código em C:

``` c
void a(int a[], int b) {
    a[b];
}
```

Que é igual a seguinte IR do llvm:

```llvm
define dso_local void @a(i32*, i32) #0 {
  %3 = alloca i32*, align 8
  %4 = alloca i32, align 4
  store i32* %0, i32** %3, align 8
  store i32 %1, i32* %4, align 4
  %5 = load i32*, i32** %3, align 8
  %6 = load i32, i32* %4, align 4
  %7 = sext i32 %6 to i64
  %8 = getelementptr inbounds i32, i32* %5, i64 %7
  %9 = load i32, i32* %8, align 4
  ret void
}
```

Então percebi que tem de alocar os parametros da função e os carai, e sempre que for usar eles tem de realizar o load dos mesmo.

Quanto a função GEP mudei para inbound, **não sei o que isso causa**.

Um exemplo do resultado que estamos gerado.

Código em nanilang:
``` python
def main(v[]: int; a: int): int {
  var x = v[a] : int;
}
```

IR LLVM:
``` llvm
define i64 @main(i64*, i64) {
entry:
  %param = alloca i64*
  store i64* %0, i64** %param
  %param1 = alloca i64
  store i64 %1, i64* %param1
  %x = alloca i64
  %flat = load i64, i64* %param1
  %loaded_param = load i64*, i64** %param
  %arr = getelementptr inbounds i64, i64* %loaded_param, i64 %flat
  %flat2 = load i64, i64* %arr
  store i64 %flat2, i64* %x
}
```

